### PR TITLE
49: add tests for content switcher component

### DIFF
--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
+
+import { TypographyVariantEnum } from '~/types'
+
+const mockOptions = {
+  left: { text: 'Left option', tooltip: 'Tooltip left' },
+  right: { text: 'Right option', tooltip: 'Tooltip right' }
+}
+
+describe('AppContentSwitcher', () => {
+  it('should render with the correct props', () => {
+    render(
+      <AppContentSwitcher
+        active
+        onChange={() => {}}
+        switchOptions={mockOptions}
+        typographyVariant='h6'
+      />
+    )
+
+    const switchElem = screen.getByRole('checkbox')
+    expect(switchElem).toBeChecked()
+
+    expect(screen.getByText('Left option')).toBeInTheDocument()
+
+    expect(screen.getByText('Right option')).toBeInTheDocument()
+
+    const leftTypography = screen.getByText('Left option')
+    expect(leftTypography).toHaveClass('MuiTypography-h6')
+  })
+
+  it('should render left and right options', () => {
+    render(
+      <AppContentSwitcher
+        active
+        onChange={() => {}}
+        switchOptions={mockOptions}
+        typographyVariant={TypographyVariantEnum.H6}
+      />
+    )
+
+    expect(screen.getByText('Left option')).toBeInTheDocument()
+    expect(screen.getByText('Right option')).toBeInTheDocument()
+  })
+
+  it('should call the onChange function when the switch is clicked', () => {
+    const handleChange = vi.fn()
+
+    render(
+      <AppContentSwitcher
+        active={false}
+        onChange={handleChange}
+        switchOptions={mockOptions}
+        typographyVariant={TypographyVariantEnum.H6}
+      />
+    )
+
+    const switchElem = screen.getByRole('checkbox')
+    fireEvent.click(switchElem)
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should apply custom styles from props', () => {
+    render(
+      <AppContentSwitcher
+        active={false}
+        onChange={() => {}}
+        styles={{ background: 'red' }}
+        switchOptions={mockOptions}
+        typographyVariant={TypographyVariantEnum.H6}
+      />
+    )
+
+    const stack = screen.getByTestId('switch').closest('.MuiStack-root')
+    expect(stack).toHaveStyle('background: red')
+  })
+
+  it('should render tooltips when tooltip props are passed', async () => {
+    render(
+      <AppContentSwitcher
+        active
+        onChange={() => {}}
+        switchOptions={mockOptions}
+        typographyVariant={TypographyVariantEnum.H6}
+      />
+    )
+
+    const leftOption = screen.getByText('Left option')
+    fireEvent.mouseOver(leftOption)
+
+    expect(await screen.findByText('Tooltip left')).toBeInTheDocument()
+
+    const rightOption = screen.getByText('Right option')
+    fireEvent.mouseOver(rightOption)
+
+    expect(await screen.findByText('Tooltip right')).toBeInTheDocument()
+  })
+})

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -11,8 +11,8 @@ const mockOptions = {
 const handleChange = vi.fn()
 
 describe('AppContentSwitcher', () => {
-  it('should render with the correct props', () => {
-    render(
+  it('should render correctly snapshot', () => {
+    const snapshot = render(
       <AppContentSwitcher
         active
         onChange={handleChange}
@@ -20,30 +20,38 @@ describe('AppContentSwitcher', () => {
         typographyVariant='h6'
       />
     )
-
-    const switchElem = screen.getByRole('checkbox')
-    expect(switchElem).toBeChecked()
-
-    expect(screen.getByText('Left option')).toBeInTheDocument()
-
-    expect(screen.getByText('Right option')).toBeInTheDocument()
-
-    const leftTypography = screen.getByText('Left option')
-    expect(leftTypography).toHaveClass('MuiTypography-h6')
+    expect(snapshot.asFragment()).toMatchSnapshot()
   })
 
-  it('should render left and right options', () => {
-    render(
-      <AppContentSwitcher
-        active
-        onChange={handleChange}
-        switchOptions={mockOptions}
-        typographyVariant={TypographyVariantEnum.H6}
-      />
-    )
+  describe('AppContentSwitcher - rendering with props', () => {
+    beforeEach(() => {
+      render(
+        <AppContentSwitcher
+          active
+          onChange={handleChange}
+          switchOptions={mockOptions}
+          typographyVariant='h6'
+        />
+      )
+    })
 
-    expect(screen.getByText('Left option')).toBeInTheDocument()
-    expect(screen.getByText('Right option')).toBeInTheDocument()
+    it('should render the switch as checked when active=true', () => {
+      const switchElem = screen.getByRole('checkbox')
+      expect(switchElem).toBeChecked()
+    })
+
+    it('should render left option text', () => {
+      expect(screen.getByText('Left option')).toBeInTheDocument()
+    })
+
+    it('should render right option text', () => {
+      expect(screen.getByText('Right option')).toBeInTheDocument()
+    })
+
+    it('should apply the correct typography variant to left option', () => {
+      const leftTypography = screen.getByText('Left option')
+      expect(leftTypography).toHaveClass('MuiTypography-h6')
+    })
   })
 
   it('should call the onChange function when the switch is clicked', () => {
@@ -77,24 +85,30 @@ describe('AppContentSwitcher', () => {
     expect(stack).toHaveStyle('background: red')
   })
 
-  it('should render tooltips when tooltip props are passed', async () => {
-    render(
-      <AppContentSwitcher
-        active
-        onChange={handleChange}
-        switchOptions={mockOptions}
-        typographyVariant={TypographyVariantEnum.H6}
-      />
-    )
+  describe('AppContentSwitcher - tooltips', () => {
+    beforeEach(() => {
+      render(
+        <AppContentSwitcher
+          active
+          onChange={handleChange}
+          switchOptions={mockOptions}
+          typographyVariant={TypographyVariantEnum.H6}
+        />
+      )
+    })
 
-    const leftOption = screen.getByText('Left option')
-    fireEvent.mouseOver(leftOption)
+    it('should show left option tooltip on hover', async () => {
+      const leftOption = screen.getByText('Left option')
+      fireEvent.mouseOver(leftOption)
 
-    expect(await screen.findByText('Tooltip left')).toBeInTheDocument()
+      expect(await screen.findByText('Tooltip left')).toBeInTheDocument()
+    })
 
-    const rightOption = screen.getByText('Right option')
-    fireEvent.mouseOver(rightOption)
+    it('should show right option tooltip on hover', async () => {
+      const rightOption = screen.getByText('Right option')
+      fireEvent.mouseOver(rightOption)
 
-    expect(await screen.findByText('Tooltip right')).toBeInTheDocument()
+      expect(await screen.findByText('Tooltip right')).toBeInTheDocument()
+    })
   })
 })

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -8,13 +8,14 @@ const mockOptions = {
   left: { text: 'Left option', tooltip: 'Tooltip left' },
   right: { text: 'Right option', tooltip: 'Tooltip right' }
 }
+const handleChange = vi.fn()
 
 describe('AppContentSwitcher', () => {
   it('should render with the correct props', () => {
     render(
       <AppContentSwitcher
         active
-        onChange={() => {}}
+        onChange={handleChange}
         switchOptions={mockOptions}
         typographyVariant='h6'
       />
@@ -35,7 +36,7 @@ describe('AppContentSwitcher', () => {
     render(
       <AppContentSwitcher
         active
-        onChange={() => {}}
+        onChange={handleChange}
         switchOptions={mockOptions}
         typographyVariant={TypographyVariantEnum.H6}
       />
@@ -46,8 +47,6 @@ describe('AppContentSwitcher', () => {
   })
 
   it('should call the onChange function when the switch is clicked', () => {
-    const handleChange = vi.fn()
-
     render(
       <AppContentSwitcher
         active={false}
@@ -67,7 +66,7 @@ describe('AppContentSwitcher', () => {
     render(
       <AppContentSwitcher
         active={false}
-        onChange={() => {}}
+        onChange={handleChange}
         styles={{ background: 'red' }}
         switchOptions={mockOptions}
         typographyVariant={TypographyVariantEnum.H6}
@@ -82,7 +81,7 @@ describe('AppContentSwitcher', () => {
     render(
       <AppContentSwitcher
         active
-        onChange={() => {}}
+        onChange={handleChange}
         switchOptions={mockOptions}
         typographyVariant={TypographyVariantEnum.H6}
       />

--- a/src/tests/unit/components/app-content-switcher/__snapshots__/AppContentSwitcher.spec.jsx.snap
+++ b/src/tests/unit/components/app-content-switcher/__snapshots__/AppContentSwitcher.spec.jsx.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppContentSwitcher > should renders correctly snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiStack-root css-1thduj9-MuiStack-root"
+  >
+    <h6
+      aria-label="Tooltip left"
+      class="MuiTypography-root MuiTypography-h6 css-7mlg6l-MuiTypography-root"
+      data-mui-internal-clone-element="true"
+    >
+      Left option
+    </h6>
+    <span
+      class="MuiSwitch-root MuiSwitch-sizeMedium css-1mmi41l-MuiSwitch-root"
+    >
+      <span
+        class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-5ryogn-MuiButtonBase-root-MuiSwitch-switchBase"
+        data-testid="switch"
+      >
+        <input
+          checked=""
+          class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+          type="checkbox"
+        />
+        <span
+          class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+      />
+    </span>
+    <h6
+      aria-label="Tooltip right"
+      class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+      data-mui-internal-clone-element="true"
+    >
+      Right option
+    </h6>
+  </div>
+</DocumentFragment>
+`;

--- a/src/tests/unit/components/app-content-switcher/__snapshots__/AppContentSwitcher.spec.jsx.snap
+++ b/src/tests/unit/components/app-content-switcher/__snapshots__/AppContentSwitcher.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AppContentSwitcher > should renders correctly snapshot 1`] = `
+exports[`AppContentSwitcher > should render correctly snapshot 1`] = `
 <DocumentFragment>
   <div
     class="MuiStack-root css-1thduj9-MuiStack-root"


### PR DESCRIPTION
Test cases:

- it should render with the correct props
- it should call the onChange function when the switch is clicked
- it should renders tooltips when tooltip props are passed

coverage run locally
<img width="917" height="53" alt="image" src="https://github.com/user-attachments/assets/733a0307-02df-4599-a525-03397384c06c" />
