### PR TITLE
50: add test for range component

### DIFF
--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -25,6 +25,19 @@ describe('AppRange', () => {
     expect(maxInput).toHaveValue('100')
   })
 
+  it('should call onChange handler with min number if first input is empty on blur', async () => {
+    const inputs = screen.getAllByRole('textbox')
+    const minInput = inputs[0]
+
+    fireEvent.change(minInput, { target: { value: '' } })
+
+    fireEvent.blur(minInput)
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith([0, 100])
+    })
+  })
+
   describe('AppRange - slider interaction', () => {
     it('should call onChange handler when min slider is changed', async () => {
       const sliders = screen.getAllByRole('slider')
@@ -104,13 +117,6 @@ describe('AppRange', () => {
       fireEvent.blur(inputs[1])
 
       expect(inputs[1]).toHaveValue('100')
-    })
-
-    it('should not call onChange when input is cleared', () => {
-      const inputs = screen.getAllByRole('textbox')
-      fireEvent.change(inputs[0], { target: { value: '' } })
-
-      expect(handleChange).not.toHaveBeenCalled()
     })
 
     it('should not call onChange handler when input is blurred with the same value', () => {

--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -1,0 +1,181 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import AppRange from '~/components/app-range/AppRange'
+
+describe('AppRange', () => {
+  const min = 13
+  const max = 78
+  const handleChange = vi.fn()
+
+  it('should renders correctly snapshot', () => {
+    const snapshot = render(
+      <AppRange max={max} min={min} onChange={handleChange} />
+    )
+    expect(snapshot.asFragment()).toMatchSnapshot()
+  })
+
+  it('should renders correctly', () => {
+    render(<AppRange max={max} min={min} onChange={handleChange} />)
+
+    const [minInput, maxInput] = screen.getAllByRole('textbox')
+
+    expect(minInput).toHaveValue('13')
+    expect(maxInput).toHaveValue('78')
+  })
+
+  describe('AppRange - slider interaction', () => {
+    it('should update call onChange handler when slider is changed', async () => {
+      render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+      const sliders = screen.getAllByRole('slider')
+
+      fireEvent.change(sliders[0], { target: { value: 20 } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled()
+      })
+    })
+
+    it('should update call onChange handler when slider is changed', async () => {
+      render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+      const sliders = screen.getAllByRole('slider')
+
+      fireEvent.change(sliders[1], { target: { value: 25 } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith([0, 25])
+      })
+    })
+  })
+
+  it('updates when input values are changed', async () => {
+    render(<AppRange max={max} min={min} onChange={handleChange} />)
+
+    const inputs = screen.getAllByRole('textbox')
+
+    fireEvent.change(inputs[0], { target: { value: '10' } })
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalled()
+      expect(inputs[0]).toHaveValue('10')
+    })
+  })
+
+  it('constrains values on blur', () => {
+    render(<AppRange max={max} min={min} onChange={handleChange} />)
+
+    const inputs = screen.getAllByRole('textbox')
+
+    fireEvent.change(inputs[1], { target: { value: '999' } })
+    fireEvent.blur(inputs[1])
+
+    expect(inputs[1]).toHaveValue(String(max))
+  })
+
+  describe('AppRange - input interaction', () => {
+    beforeEach(() => {
+      render(<AppRange max={100} min={0} onChange={handleChange} />)
+    })
+
+    it('should render two input fields', () => {
+      const inputs = screen.getAllByRole('textbox')
+      expect(inputs).toHaveLength(2)
+    })
+
+    it('should call onChange when first input is changed', async () => {
+      const inputs = screen.getAllByRole('textbox')
+      fireEvent.change(inputs[0], { target: { value: '10' } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled()
+      })
+    })
+
+    it('should call onChange when second input is changed', async () => {
+      const inputs = screen.getAllByRole('textbox')
+      fireEvent.change(inputs[1], { target: { value: '90' } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled()
+      })
+    })
+
+    it('should pass the correct final range to onChange after both inputs are changed', async () => {
+      const inputs = screen.getAllByRole('textbox')
+      fireEvent.change(inputs[0], { target: { value: '10' } })
+      fireEvent.change(inputs[1], { target: { value: '90' } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenLastCalledWith([10, 90])
+      })
+    })
+  })
+
+  describe('AppRange - invalid input handling', () => {
+    const handleChange = vi.fn()
+    it('should not call onChange when input is changed with non-numeric value', () => {
+      render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+      const inputs = screen.getAllByRole('textbox')
+      fireEvent.change(inputs[0], { target: { value: 'abc' } })
+
+      expect(handleChange).not.toHaveBeenCalled()
+    })
+
+    it('should not call onChange when input is cleared', () => {
+      render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+      const inputs = screen.getAllByRole('textbox')
+      fireEvent.change(inputs[0], { target: { value: '' } })
+
+      expect(handleChange).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should call onChange with min number if first input is empty on blur', async () => {
+    const handleChange = vi.fn()
+    render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+    const inputs = screen.getAllByRole('textbox')
+    const minInput = inputs[0]
+
+    fireEvent.change(minInput, { target: { value: '' } })
+
+    fireEvent.blur(minInput)
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith([0, 100])
+    })
+  })
+
+  it('should update value to max when second input is blurred with value greater than max', async () => {
+    const handleChange = vi.fn()
+    render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+    const inputs = screen.getAllByRole('textbox')
+    const maxInput = inputs[1]
+
+    fireEvent.change(maxInput, { target: { value: '150' } })
+
+    fireEvent.blur(maxInput)
+
+    await waitFor(() => {
+      expect(maxInput).toHaveValue('100')
+    })
+  })
+
+  it('should not update or call onChange when input is blurred with the same value', () => {
+    const handleChange = vi.fn()
+    render(<AppRange max={100} min={0} onChange={handleChange} />)
+
+    const inputs = screen.getAllByRole('textbox')
+    const minInput = inputs[0]
+
+    fireEvent.blur(minInput)
+
+    expect(handleChange).not.toHaveBeenCalled()
+
+    expect(minInput).toHaveValue('0')
+  })
+})

--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -18,7 +18,7 @@ describe('AppRange', () => {
     expect(snapshot.asFragment()).toMatchSnapshot()
   })
 
-  it('should renders correctly', () => {
+  it('should render inputs with value from props', () => {
     const [minInput, maxInput] = screen.getAllByRole('textbox')
 
     expect(minInput).toHaveValue('0')
@@ -26,7 +26,7 @@ describe('AppRange', () => {
   })
 
   describe('AppRange - slider interaction', () => {
-    it('should update call onChange handler when min slider is changed', async () => {
+    it('should call onChange handler when min slider is changed', async () => {
       const sliders = screen.getAllByRole('slider')
 
       fireEvent.change(sliders[0], { target: { value: 20 } })
@@ -36,7 +36,7 @@ describe('AppRange', () => {
       })
     })
 
-    it('should update call onChange handler when max slider is changed', async () => {
+    it('should call onChange handler when max slider is changed', async () => {
       const sliders = screen.getAllByRole('slider')
 
       fireEvent.change(sliders[1], { target: { value: 25 } })
@@ -53,32 +53,22 @@ describe('AppRange', () => {
       expect(inputs).toHaveLength(2)
     })
 
-    it('updates when input values are changed', async () => {
+    it('should call onChange handler after from input is changed', async () => {
       const inputs = screen.getAllByRole('textbox')
 
       fireEvent.change(inputs[0], { target: { value: '10' } })
 
       await waitFor(() => {
-        expect(handleChange).toHaveBeenCalled()
-        expect(inputs[0]).toHaveValue('10')
+        expect(handleChange).toHaveBeenCalledWith([10, 100])
       })
     })
 
-    it('should call onChange when first input is changed', async () => {
-      const inputs = screen.getAllByRole('textbox')
-      fireEvent.change(inputs[0], { target: { value: '10' } })
-
-      await waitFor(() => {
-        expect(handleChange).toHaveBeenCalled()
-      })
-    })
-
-    it('should call onChange when second input is changed', async () => {
+    it('should call onChange handler after second input is changed', async () => {
       const inputs = screen.getAllByRole('textbox')
       fireEvent.change(inputs[1], { target: { value: '90' } })
 
       await waitFor(() => {
-        expect(handleChange).toHaveBeenCalled()
+        expect(handleChange).toHaveBeenCalledWith([0, 90])
       })
     })
 
@@ -107,7 +97,7 @@ describe('AppRange', () => {
       expect(handleChange).not.toHaveBeenCalled()
     })
 
-    it('constrains values on blur', () => {
+    it('should constrain values on blur', () => {
       const inputs = screen.getAllByRole('textbox')
 
       fireEvent.change(inputs[1], { target: { value: '999' } })
@@ -123,7 +113,7 @@ describe('AppRange', () => {
       expect(handleChange).not.toHaveBeenCalled()
     })
 
-    it('should not update or call onChange when input is blurred with the same value', () => {
+    it('should not call onChange handler when input is blurred with the same value', () => {
       const inputs = screen.getAllByRole('textbox')
       const minInput = inputs[0]
 

--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -3,9 +3,13 @@ import { describe, it, expect, vi } from 'vitest'
 import AppRange from '~/components/app-range/AppRange'
 
 describe('AppRange', () => {
-  const min = 13
-  const max = 78
+  const min = 0
+  const max = 100
   const handleChange = vi.fn()
+
+  beforeEach(() => {
+    render(<AppRange max={max} min={min} onChange={handleChange} />)
+  })
 
   it('should renders correctly snapshot', () => {
     const snapshot = render(
@@ -15,18 +19,14 @@ describe('AppRange', () => {
   })
 
   it('should renders correctly', () => {
-    render(<AppRange max={max} min={min} onChange={handleChange} />)
-
     const [minInput, maxInput] = screen.getAllByRole('textbox')
 
-    expect(minInput).toHaveValue('13')
-    expect(maxInput).toHaveValue('78')
+    expect(minInput).toHaveValue('0')
+    expect(maxInput).toHaveValue('100')
   })
 
   describe('AppRange - slider interaction', () => {
-    it('should update call onChange handler when slider is changed', async () => {
-      render(<AppRange max={100} min={0} onChange={handleChange} />)
-
+    it('should update call onChange handler when min slider is changed', async () => {
       const sliders = screen.getAllByRole('slider')
 
       fireEvent.change(sliders[0], { target: { value: 20 } })
@@ -36,9 +36,7 @@ describe('AppRange', () => {
       })
     })
 
-    it('should update call onChange handler when slider is changed', async () => {
-      render(<AppRange max={100} min={0} onChange={handleChange} />)
-
+    it('should update call onChange handler when max slider is changed', async () => {
       const sliders = screen.getAllByRole('slider')
 
       fireEvent.change(sliders[1], { target: { value: 25 } })
@@ -49,38 +47,21 @@ describe('AppRange', () => {
     })
   })
 
-  it('updates when input values are changed', async () => {
-    render(<AppRange max={max} min={min} onChange={handleChange} />)
-
-    const inputs = screen.getAllByRole('textbox')
-
-    fireEvent.change(inputs[0], { target: { value: '10' } })
-
-    await waitFor(() => {
-      expect(handleChange).toHaveBeenCalled()
-      expect(inputs[0]).toHaveValue('10')
-    })
-  })
-
-  it('constrains values on blur', () => {
-    render(<AppRange max={max} min={min} onChange={handleChange} />)
-
-    const inputs = screen.getAllByRole('textbox')
-
-    fireEvent.change(inputs[1], { target: { value: '999' } })
-    fireEvent.blur(inputs[1])
-
-    expect(inputs[1]).toHaveValue(String(max))
-  })
-
   describe('AppRange - input interaction', () => {
-    beforeEach(() => {
-      render(<AppRange max={100} min={0} onChange={handleChange} />)
-    })
-
     it('should render two input fields', () => {
       const inputs = screen.getAllByRole('textbox')
       expect(inputs).toHaveLength(2)
+    })
+
+    it('updates when input values are changed', async () => {
+      const inputs = screen.getAllByRole('textbox')
+
+      fireEvent.change(inputs[0], { target: { value: '10' } })
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled()
+        expect(inputs[0]).toHaveValue('10')
+      })
     })
 
     it('should call onChange when first input is changed', async () => {
@@ -112,70 +93,58 @@ describe('AppRange', () => {
     })
   })
 
-  describe('AppRange - invalid input handling', () => {
+  describe('AppRange - invalid and blur input handling', () => {
     const handleChange = vi.fn()
-    it('should not call onChange when input is changed with non-numeric value', () => {
-      render(<AppRange max={100} min={0} onChange={handleChange} />)
 
+    beforeEach(() => {
+      render(<AppRange max={max} min={min} onChange={handleChange} />)
+    })
+
+    it('should not call onChange when input is changed with non-numeric value', () => {
       const inputs = screen.getAllByRole('textbox')
       fireEvent.change(inputs[0], { target: { value: 'abc' } })
 
       expect(handleChange).not.toHaveBeenCalled()
     })
 
-    it('should not call onChange when input is cleared', () => {
-      render(<AppRange max={100} min={0} onChange={handleChange} />)
+    it('constrains values on blur', () => {
+      const inputs = screen.getAllByRole('textbox')
 
+      fireEvent.change(inputs[1], { target: { value: '999' } })
+      fireEvent.blur(inputs[1])
+
+      expect(inputs[1]).toHaveValue('100')
+    })
+
+    it('should not call onChange when input is cleared', () => {
       const inputs = screen.getAllByRole('textbox')
       fireEvent.change(inputs[0], { target: { value: '' } })
 
       expect(handleChange).not.toHaveBeenCalled()
     })
-  })
 
-  it('should call onChange with min number if first input is empty on blur', async () => {
-    const handleChange = vi.fn()
-    render(<AppRange max={100} min={0} onChange={handleChange} />)
+    it('should not update or call onChange when input is blurred with the same value', () => {
+      const inputs = screen.getAllByRole('textbox')
+      const minInput = inputs[0]
 
-    const inputs = screen.getAllByRole('textbox')
-    const minInput = inputs[0]
+      fireEvent.blur(minInput)
 
-    fireEvent.change(minInput, { target: { value: '' } })
+      expect(handleChange).not.toHaveBeenCalled()
 
-    fireEvent.blur(minInput)
-
-    await waitFor(() => {
-      expect(handleChange).toHaveBeenLastCalledWith([0, 100])
+      expect(minInput).toHaveValue('0')
     })
-  })
 
-  it('should update value to max when second input is blurred with value greater than max', async () => {
-    const handleChange = vi.fn()
-    render(<AppRange max={100} min={0} onChange={handleChange} />)
+    it('should update value to max when second input is blurred with value greater than max', async () => {
+      const inputs = screen.getAllByRole('textbox')
+      const maxInput = inputs[1]
 
-    const inputs = screen.getAllByRole('textbox')
-    const maxInput = inputs[1]
+      fireEvent.change(maxInput, { target: { value: '150' } })
 
-    fireEvent.change(maxInput, { target: { value: '150' } })
+      fireEvent.blur(maxInput)
 
-    fireEvent.blur(maxInput)
-
-    await waitFor(() => {
-      expect(maxInput).toHaveValue('100')
+      await waitFor(() => {
+        expect(maxInput).toHaveValue('100')
+      })
     })
-  })
-
-  it('should not update or call onChange when input is blurred with the same value', () => {
-    const handleChange = vi.fn()
-    render(<AppRange max={100} min={0} onChange={handleChange} />)
-
-    const inputs = screen.getAllByRole('textbox')
-    const minInput = inputs[0]
-
-    fireEvent.blur(minInput)
-
-    expect(handleChange).not.toHaveBeenCalled()
-
-    expect(minInput).toHaveValue('0')
   })
 })

--- a/src/tests/unit/components/app-range/__snapshots__/AppRange.spec.jsx.snap
+++ b/src/tests/unit/components/app-range/__snapshots__/AppRange.spec.jsx.snap
@@ -26,7 +26,7 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
         data-index="0"
         style="left: 0%;"
       >
-        13
+        0
       </span>
       <span
         class="MuiSlider-mark MuiSlider-markActive css-6cwnna-MuiSlider-mark"
@@ -39,7 +39,7 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
         data-index="1"
         style="left: 100%;"
       >
-        78
+        100
       </span>
       <span
         class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-cv58vo-MuiSlider-thumb"
@@ -49,16 +49,16 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
       >
         <input
           aria-orientation="horizontal"
-          aria-valuemax="78"
-          aria-valuemin="13"
-          aria-valuenow="13"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="0"
           data-index="0"
-          max="78"
-          min="13"
+          max="100"
+          min="0"
           step="1"
           style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
           type="range"
-          value="13"
+          value="0"
         />
       </span>
       <span
@@ -69,16 +69,16 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
       >
         <input
           aria-orientation="horizontal"
-          aria-valuemax="78"
-          aria-valuemin="13"
-          aria-valuenow="78"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="100"
           data-index="1"
-          max="78"
-          min="13"
+          max="100"
+          min="0"
           step="1"
           style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
           type="range"
-          value="78"
+          value="100"
         />
       </span>
     </span>
@@ -106,7 +106,7 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
               id="0"
               inputmode="numeric"
               type="text"
-              value="13"
+              value="0"
             />
             <fieldset
               aria-hidden="true"
@@ -145,7 +145,7 @@ exports[`AppRange > should renders correctly snapshot 1`] = `
               id="1"
               inputmode="numeric"
               type="text"
-              value="78"
+              value="100"
             />
             <fieldset
               aria-hidden="true"

--- a/src/tests/unit/components/app-range/__snapshots__/AppRange.spec.jsx.snap
+++ b/src/tests/unit/components/app-range/__snapshots__/AppRange.spec.jsx.snap
@@ -1,0 +1,170 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppRange > should renders correctly snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiStack-root css-16ago1c-MuiStack-root"
+  >
+    <span
+      class="MuiSlider-root MuiSlider-marked MuiSlider-colorPrimary MuiSlider-sizeSmall css-c5og8r-MuiSlider-root"
+    >
+      <span
+        class="MuiSlider-rail css-14pt78w-MuiSlider-rail"
+      />
+      <span
+        class="MuiSlider-track css-1n40zqk-MuiSlider-track"
+        style="left: 0%; width: 100%;"
+      />
+      <span
+        class="MuiSlider-mark MuiSlider-markActive css-6cwnna-MuiSlider-mark"
+        data-index="0"
+        style="left: 0%;"
+      />
+      <span
+        aria-hidden="true"
+        class="MuiSlider-markLabel MuiSlider-markLabel MuiSlider-markLabelActive css-1eoe787-MuiSlider-markLabel"
+        data-index="0"
+        style="left: 0%;"
+      >
+        13
+      </span>
+      <span
+        class="MuiSlider-mark MuiSlider-markActive css-6cwnna-MuiSlider-mark"
+        data-index="1"
+        style="left: 100%;"
+      />
+      <span
+        aria-hidden="true"
+        class="MuiSlider-markLabel MuiSlider-markLabel MuiSlider-markLabelActive css-1eoe787-MuiSlider-markLabel"
+        data-index="1"
+        style="left: 100%;"
+      >
+        78
+      </span>
+      <span
+        class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-cv58vo-MuiSlider-thumb"
+        data-index="0"
+        data-mui-internal-clone-element="true"
+        style="left: 0%;"
+      >
+        <input
+          aria-orientation="horizontal"
+          aria-valuemax="78"
+          aria-valuemin="13"
+          aria-valuenow="13"
+          data-index="0"
+          max="78"
+          min="13"
+          step="1"
+          style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+          type="range"
+          value="13"
+        />
+      </span>
+      <span
+        class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-cv58vo-MuiSlider-thumb"
+        data-index="1"
+        data-mui-internal-clone-element="true"
+        style="left: 100%;"
+      >
+        <input
+          aria-orientation="horizontal"
+          aria-valuemax="78"
+          aria-valuemin="13"
+          aria-valuenow="78"
+          data-index="1"
+          max="78"
+          min="13"
+          step="1"
+          style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+          type="range"
+          value="78"
+        />
+      </span>
+    </span>
+    <div
+      class="MuiBox-root css-0"
+      style="display: flex; gap: 24px;"
+    >
+      <div
+        class="MuiBox-root css-1uezowt"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-c200zg-MuiTypography-root"
+        >
+          common.from
+        </p>
+        <div
+          class="MuiFormControl-root MuiTextField-root css-10vsn2f-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+              id="0"
+              inputmode="numeric"
+              type="text"
+              value="13"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1uezowt"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-c200zg-MuiTypography-root"
+        >
+          common.to
+        </p>
+        <div
+          class="MuiFormControl-root MuiTextField-root css-10vsn2f-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+              id="1"
+              inputmode="numeric"
+              type="text"
+              value="78"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Add unit tests for the range component

- it should renders correctly = should renders correctly snapshot

- it should call onChange when slider is moved = AppRange - slider interaction: should call onChange handler when min slider is changed, should call onChange handler when max slider is changed
 
- it should call onChange when input is changed= AppRange - input interaction: should call onChange handler after from input is changed

- it should not call onChange when input is changed wit not a number = AppRange - invalid and blur input handling: should not call onChange when input is changed with non-numeric value

- it should call onChange whith min number if input is empty = should call onChange handler with min number if first input is empty on blur

- it should update prices when input is blurred and input is greater than max value = AppRange - invalid and blur input handling: should update value to max when second input is blurred with value greater than max

- it should not update prices when input is blurred and value in input has not changed = AppRange - invalid and blur input handling: should not call onChange handler when input is blurred with the same value

Coverage run locally 
<img width="917" height="46" alt="image" src="https://github.com/user-attachments/assets/ef4f836c-ffac-44c4-9765-4b45185895d2" />
