### PR TITLE
[234] Fix description text in password reset window

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
@@ -78,11 +78,13 @@ const ForgotPassword = () => {
 
   return (
     <Box sx={styles.root}>
-      <TitleWithDescription
-        description={t('login.enterEmail')}
-        style={styles.titleWithDescription}
-        title={t('login.forgotPassword')}
-      />
+      <Box sx={{ mb: '20px' }}>
+        <TitleWithDescription
+          description={t('login.enterEmail')}
+          style={styles.titleWithDescription}
+          title={t('login.forgotPassword')}
+        />
+      </Box>
 
       <Box component='form' onSubmit={handleSubmit}>
         <AppTextField

--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
@@ -78,13 +78,11 @@ const ForgotPassword = () => {
 
   return (
     <Box sx={styles.root}>
-      <Box sx={{ mb: '20px' }}>
-        <TitleWithDescription
-          description={t('login.enterEmail')}
-          style={styles.titleWithDescription}
-          title={t('login.forgotPassword')}
-        />
-      </Box>
+      <TitleWithDescription
+        description={t('login.enterEmail')}
+        style={styles.titleWithDescription}
+        title={t('login.forgotPassword')}
+      />
 
       <Box component='form' onSubmit={handleSubmit}>
         <AppTextField

--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -25,7 +25,8 @@ export const styles = {
       mb: '16px'
     },
     description: {
-      typography: 'body2'
+      typography: 'body2',
+      mb: '20px'
     }
   }
 }


### PR DESCRIPTION
Ticket: [Space2Study-UA-4427-4288-01-2/Issues/#234](https://github.com/Space2Study-UA-4427-4288-01-2/Issues/issues/234)

## Bug:
- In password reset window the “Email” input field is overlapped by description text

### What was done:
- The margin - bottom was add.